### PR TITLE
feat(content): add audio playback functionality alongside quotes

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
   <!-- Audio di sottofondo nascosto -->
   <audio id="bg-music" autoplay loop preload="auto">
     <source src="assets/theme.mp3" type="audio/mpeg" />
-    Il tuo browser non supporta l’elemento audio.
+    Il tuo browser non supporta l'elemento audio.
   </audio>
 
   <!-- Slogan cliccabile -->

--- a/quotes.json
+++ b/quotes.json
@@ -1,95 +1,100 @@
 {
-  "sbrzt": [
-    "Uploaded. Ottimo. Ora clicco Withdraw. No dai, oggi no. \n Però sai cosa pensavo? Una volta dovremmo organizzarci, tutti noi del DHarc, scrivere un paper ciascuno per una conferenza importante, tutti la stessa. Poi a mezz'ora dalla deadline ci chiudiamo a chiave in una stanza, facciamo l'upload. Poi per i ventinove minuti successivi alterniamo WITHDRAW e UPLOAD, fino alla fine. \n Una roulette russa.",
-    "Io te lo giuro se ci sono problemi con questa submission sbatto la testa contro una colonna di cemento. \n Sono pronto a ridipingere un muro.",
-    "Siamo tutti botroidi",
-    "Poi quando riesci fammi sapere anche su questo così so quando devo infilare una forchetta in una presa della corrente",
-    "Lo userò per fare un crosswalk e convertire la mia voglia di dormire per sempre in una voglia sfrenata di cacciucco",
-    "morto dentro, vivo fuori, zombie nel complesso",
-    "OpenReview, certo. Il concetto di form incarnato nella merda."
-  ],
-  "ValentinaPasqual": [
-    "Sogno un giorno di diventare Editor o Chair per brevettare la *cute rejection*. \n In pratica se vieni rigettato il messaggio che ricevi inizia con 'Despite you being a cute pinenut ...'.",
-    "Tu sei estremamente piccolo, un pinolo.",
-    "Stamattina mi sono svegliata fredda",
-    "You are an aggressive wall, Arianna.",
-    "Non mi sono svegliata elegante. Però rimpiango un po' di essermi svegliata casual."
-  ],
-  "lucipess": [
-    "Maria temo che il contesto di povertà in cui versa l'accademia italiana sia piuttosto lontano dalle tue aspettative purtroppo",
-    "Dottorato. Seconda adolescenza.",
-    "Mai come cristo crocifisso in sella a Martina sia chiaro"
-
-  ],
-  "frami": [
-    "Oggi do fuoco al dipartimento",
-    "raga boh è tutto così… sbagliato che è quasi giusto",
-    "Alcune cose forse non devono succedere",
-    "Senti le slides sono mie e ci faccio quello che mi pare. "
-  ],
-  "eliarizzetto": [
-    "Come va oggi? Ancora in mano a Cristo?",
-    "Ma guarda volevo sistemarmeli ma poi mi sembrava di essere vanitoso in webcam e ho deciso di lasciare che i miei ciuffi prendessero delle decisioni autonomamente",
-    "Il Bologna ha vinto la finale di Coppa Italia quindi ora fuori per strada sembra Berlino quando è caduto il muro"
-  ],
-  "StenDoipanni": [
-    "Oggi ho pagato il 'bica' da un paki ad un uomo in ciabatte in via Mascarella che mi aveva chiesto di 'comprargli una cosa', alimentando i pregiudizi dei miei amici del Nord sulla Bologna sporca e comunista.",
-    "ho dovuto leggere più volte per non avere l’enfasi della bestemmia, ma alla fine ho capito",
-    "è solo lunedì e già abbiamo una valida candidata al premio settimanale “snitchinə d’oro”",
-    "Un risveglio inaspettato. Nel senso che anche oggi è inaspettato che mi svegliassi. Ma è bello stupirsi delle piccole cose"
-  ],
-  "Citazioni Corali": [
-    "Ammesso che domani mattina non ci svegliamo eleganti",
-    "Sempre che non ci svegliamo col cappotto di legno"
-  ],
-  "aschimmenti": [
-    "L'unica richiesta che vorrei far approvare dal collegio è un daspo universitario, per favore",
-    "Io ormai non dico più che studio digital humanities dico solo la risposta più sensata per l'ascoltatore \n- Se cerco casa dico che studio informatica perché rassicura i landlord per l'accesso al capitale \n- se parlo con un tecnico dico che studio lettere \n- se parlo con un letterato dico che studio infomatica \n- se parlo con mia nonna dico che studio i computer \n- se parlo con uno studente di lettere o di informatica cerco di confonderlo il più possibile",
-    "Nono, torno a Palermo, divento piromane. Causa #1 degli incendi. Il cambiamento climatico sarò io.",
-    "Sbatti i tacchi tre volte e si materializza Ivan. Scientifico.",
-    "Reazione base quando la giornata è stata troppo stressante (ho dovuto rispondere ad una mail di uno studente che chiedeva info su un esame)",
-    "Voglio tornare a rotolare sull'erba",
-    "Magari se urlo abbastanza sul cuscino mi viene sonno",
-    "Mi serve una di quelle cose che vibrano così mi rilasso i muscoli del collo e riesco a dormire. Cioè una granata.",
-    "Questa cosa la metto tra le 13 ragioni per cui svegliarmi (immagina le altre 12)",
-    "Arianna il primo LLM con adhd ed emozioni forti su uno specifico set di termini con distanza cosenica molto vicino al 'sapore'",
-    "STASERA VAI A DORMIRE CON INRI SCRITTO SULLA TESTATA DEL LETTO"
-  ],
-  "alibordi":[
-    "pronto polizia dei metadati"
-  ],
-  "arcangelo7": [
-    "Dopo un anno in Belgio sono giunto alla conclusione che il problema dell'Europa sia avere la capitale in Belgio. \n Se Bruxelles fosse a Napoli oggi saremmo la prima potenza mondiale",
-    "Scusa mi manderesti uno screenshot dell'email? Così, per ricordo",
-    "Forse in futuro fonderò il Partito delle Scimmie, che si propone di riportare la società all'età della pietra",
-    "Ho appena avuto un'idea di contributo per il TRT2 AI e Metaverso. \n La domanda di ricerca è la seguente: ma Hentry Kissinger e Giulio Andreotti sono in realtà la stessa persona? \n Ti dico alcune frasi famose di Kissinger che sembrano pronunciate da Andreotti: 'Ciò che mi interessa è quello che si può fare con il potere', 'Gli Stati non hanno né amici permanenti né nemici permanenti: hanno solo interessi'. \n Pensavo poi di mettere nei future work l'ipotesi rettiliana, che rimane comunque una mera suggestione senza pretesa di volerla dimostrare.",
-    "Che benchmark ha usato per fare questa affermazione?",
-    "Comunque queste non sono Humanities, questa è Fuffology. Dire cose a caso spacciandole per vere",
-    "Io sono talmente rassegnato a UnaEuropa che resto. Ha vinto.",
-    "Dopo questo workshop sono sempre più convinto che sia giusto togliere soldi alla cultura per comprare i cannoni",
-    "Cerca invano di riempire i propri vuoti riempiendo il proprio curriculum",
-    "Al bar l'ultima spiaggia dove i geppetti pensionati si incontrato per giocare a carte la barista geppetta allenata solo su un corpus cinese conosce shacl",
-    "Comunque più clicco su Dimmi di più, più mi rendo conto che io e aschimmenti se usciamo dall'Italia non è detto che ci facciano rientrare",
-    "Io boh... Chi devo votare per abolire il ministero della cultura? Ah no, va già bene Giuli dai"
-  ],
-  "giuliarenda_mondoboia": [
-    "Grazie al cielo io non arrivo mai in fondo a questa mail, altrimenti mi davo fuoco",
-    "Se non l'avessi mai vista ti direi 'ha un ritardo'",
-    "Scusate, i momenti in cui faccio più ridere sono quelli in cui sono seria"
-  ],
-  "essepuntato": [
-    "Prossimo trasloco 3 metri sotto terra e non me ne occupo io."
-  ],
-  "_brevelunga_":
-  [ "Ivan ti prego non costringermi ad inviare delle email istituzionali che hanno come oggetto 'Sorry for Ivan'.",
-    "Ivan oggi ha visto la droga."
-  ],
-  "ivanhb": [
-    "effettivamente questa cosa mi sta facendo riflettere. \n Mi scollego. \n Non solo dal meeting."
-  ],
-  "arietti": [
-    "La parte dead della deadline sono io."
-  ],
-  "RemoGrillo": [
-  ]
+  "quotes": {
+    "sbrzt": [
+      "Uploaded. Ottimo. Ora clicco Withdraw. No dai, oggi no. \n Però sai cosa pensavo? Una volta dovremmo organizzarci, tutti noi del DHarc, scrivere un paper ciascuno per una conferenza importante, tutti la stessa. Poi a mezz'ora dalla deadline ci chiudiamo a chiave in una stanza, facciamo l'upload. Poi per i ventinove minuti successivi alterniamo WITHDRAW e UPLOAD, fino alla fine. \n Una roulette russa.",
+      "Io te lo giuro se ci sono problemi con questa submission sbatto la testa contro una colonna di cemento. \n Sono pronto a ridipingere un muro.",
+      "Siamo tutti botroidi",
+      "Poi quando riesci fammi sapere anche su questo così so quando devo infilare una forchetta in una presa della corrente",
+      "Lo userò per fare un crosswalk e convertire la mia voglia di dormire per sempre in una voglia sfrenata di cacciucco",
+      "morto dentro, vivo fuori, zombie nel complesso",
+      "OpenReview, certo. Il concetto di form incarnato nella merda."
+    ],
+    "ValentinaPasqual": [
+      "Sogno un giorno di diventare Editor o Chair per brevettare la *cute rejection*. \n In pratica se vieni rigettato il messaggio che ricevi inizia con 'Despite you being a cute pinenut ...'.",
+      "Tu sei estremamente piccolo, un pinolo.",
+      "Stamattina mi sono svegliata fredda",
+      "You are an aggressive wall, Arianna.",
+      "Non mi sono svegliata elegante. Però rimpiango un po' di essermi svegliata casual."
+    ],
+    "lucipess": [
+      "Maria temo che il contesto di povertà in cui versa l'accademia italiana sia piuttosto lontano dalle tue aspettative purtroppo",
+      "Dottorato. Seconda adolescenza.",
+      "Mai come cristo crocifisso in sella a Martina sia chiaro"
+    ],
+    "frami": [
+      "Oggi do fuoco al dipartimento",
+      "raga boh è tutto così… sbagliato che è quasi giusto",
+      "Alcune cose forse non devono succedere",
+      "Senti le slides sono mie e ci faccio quello che mi pare. "
+    ],
+    "eliarizzetto": [
+      "Come va oggi? Ancora in mano a Cristo?",
+      "Ma guarda volevo sistemarmeli ma poi mi sembrava di essere vanitoso in webcam e ho deciso di lasciare che i miei ciuffi prendessero delle decisioni autonomamente",
+      "Il Bologna ha vinto la finale di Coppa Italia quindi ora fuori per strada sembra Berlino quando è caduto il muro"
+    ],
+    "StenDoipanni": [
+      "Oggi ho pagato il 'bica' da un paki ad un uomo in ciabatte in via Mascarella che mi aveva chiesto di 'comprargli una cosa', alimentando i pregiudizi dei miei amici del Nord sulla Bologna sporca e comunista.",
+      "ho dovuto leggere più volte per non avere l’enfasi della bestemmia, ma alla fine ho capito",
+      "è solo lunedì e già abbiamo una valida candidata al premio settimanale “snitchinə d’oro”",
+      "Un risveglio inaspettato. Nel senso che anche oggi è inaspettato che mi svegliassi. Ma è bello stupirsi delle piccole cose"
+    ],
+    "Citazioni Corali": [
+      "Ammesso che domani mattina non ci svegliamo eleganti",
+      "Sempre che non ci svegliamo col cappotto di legno"
+    ],
+    "aschimmenti": [
+      "L'unica richiesta che vorrei far approvare dal collegio è un daspo universitario, per favore",
+      "Io ormai non dico più che studio digital humanities dico solo la risposta più sensata per l'ascoltatore \n- Se cerco casa dico che studio informatica perché rassicura i landlord per l'accesso al capitale \n- se parlo con un tecnico dico che studio lettere \n- se parlo con un letterato dico che studio infomatica \n- se parlo con mia nonna dico che studio i computer \n- se parlo con uno studente di lettere o di informatica cerco di confonderlo il più possibile",
+      "Nono, torno a Palermo, divento piromane. Causa #1 degli incendi. Il cambiamento climatico sarò io.",
+      "Sbatti i tacchi tre volte e si materializza Ivan. Scientifico.",
+      "Reazione base quando la giornata è stata troppo stressante (ho dovuto rispondere ad una mail di uno studente che chiedeva info su un esame)",
+      "Voglio tornare a rotolare sull'erba",
+      "Magari se urlo abbastanza sul cuscino mi viene sonno",
+      "Mi serve una di quelle cose che vibrano così mi rilasso i muscoli del collo e riesco a dormire. Cioè una granata.",
+      "Questa cosa la metto tra le 13 ragioni per cui svegliarmi (immagina le altre 12)",
+      "Arianna il primo LLM con adhd ed emozioni forti su uno specifico set di termini con distanza cosenica molto vicino al 'sapore'",
+      "STASERA VAI A DORMIRE CON INRI SCRITTO SULLA TESTATA DEL LETTO"
+    ],
+    "alibordi": [
+      "pronto polizia dei metadati"
+    ],
+    "arcangelo7": [
+      "Dopo un anno in Belgio sono giunto alla conclusione che il problema dell'Europa sia avere la capitale in Belgio. \n Se Bruxelles fosse a Napoli oggi saremmo la prima potenza mondiale",
+      "Scusa mi manderesti uno screenshot dell'email? Così, per ricordo",
+      "Forse in futuro fonderò il Partito delle Scimmie, che si propone di riportare la società all'età della pietra",
+      "Ho appena avuto un'idea di contributo per il TRT2 AI e Metaverso. \n La domanda di ricerca è la seguente: ma Hentry Kissinger e Giulio Andreotti sono in realtà la stessa persona? \n Ti dico alcune frasi famose di Kissinger che sembrano pronunciate da Andreotti: 'Ciò che mi interessa è quello che si può fare con il potere', 'Gli Stati non hanno né amici permanenti né nemici permanenti: hanno solo interessi'. \n Pensavo poi di mettere nei future work l'ipotesi rettiliana, che rimane comunque una mera suggestione senza pretesa di volerla dimostrare.",
+      "Che benchmark ha usato per fare questa affermazione?",
+      "Comunque queste non sono Humanities, questa è Fuffology. Dire cose a caso spacciandole per vere",
+      "Io sono talmente rassegnato a UnaEuropa che resto. Ha vinto.",
+      "Dopo questo workshop sono sempre più convinto che sia giusto togliere soldi alla cultura per comprare i cannoni",
+      "Cerca invano di riempire i propri vuoti riempiendo il proprio curriculum",
+      "Al bar l'ultima spiaggia dove i geppetti pensionati si incontrato per giocare a carte la barista geppetta allenata solo su un corpus cinese conosce shacl",
+      "Comunque più clicco su Dimmi di più, più mi rendo conto che io e aschimmenti se usciamo dall'Italia non è detto che ci facciano rientrare",
+      "Io boh... Chi devo votare per abolire il ministero della cultura? Ah no, va già bene Giuli dai"
+    ],
+    "giuliarenda_mondoboia": [
+      "Grazie al cielo io non arrivo mai in fondo a questa mail, altrimenti mi davo fuoco",
+      "Se non l'avessi mai vista ti direi 'ha un ritardo'",
+      "Scusate, i momenti in cui faccio più ridere sono quelli in cui sono seria"
+    ],
+    "essepuntato": [
+      "Prossimo trasloco 3 metri sotto terra e non me ne occupo io."
+    ],
+    "_brevelunga_": [
+      "Ivan ti prego non costringermi ad inviare delle email istituzionali che hanno come oggetto 'Sorry for Ivan'.",
+      "Ivan oggi ha visto la droga."
+    ],
+    "ivanhb": [
+      "effettivamente questa cosa mi sta facendo riflettere. \n Mi scollego. \n Non solo dal meeting."
+    ],
+    "arietti": [
+      "La parte dead della deadline sono io."
+    ],
+    "RemoGrillo": []
+  },
+  "audio": {
+    "arietti": [
+      "assets/audio/semantic_web.mp3"
+    ]
+  }
 }

--- a/style.css
+++ b/style.css
@@ -111,6 +111,30 @@ button:hover {
   background: #c0392b;
 }
 
+.audio-content {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.audio-content audio {
+  width: 100%;
+  margin: 0.5rem 0;
+  border-radius: 0.5rem;
+}
+
+audio::-webkit-media-controls-panel {
+  background-color: rgba(231, 76, 60, 0.1);
+}
+
+audio::-webkit-media-controls-play-button {
+  background-color: #e74c3c;
+  border-radius: 50%;
+}
+
+audio::-webkit-media-controls-play-button:hover {
+  background-color: #c0392b;
+}
+
 /* Footer */
 .footer {
   position: absolute;


### PR DESCRIPTION
This commit adds audio content support to the DHark application, allowing users to experience both quotes and audio clips. Key changes include:

- Restructured JSON data with a symmetrical format for both quotes and audio content
- Added audio playback functionality that automatically plays when selected
- Implemented background music management (pauses during audio content playback)
- Created a unified content handling system that treats quotes and audio equally
- Added author attribution for audio content matching the quote display style
- Ensured each content item (quote or audio) is shown only once per session
- Added CSS styling for audio elements to match the application's aesthetic